### PR TITLE
Fix: add parsers to <b>, <i> and <u> elements

### DIFF
--- a/dist/trix-core.js
+++ b/dist/trix-core.js
@@ -1,7 +1,7 @@
 
 /*
 Trix 0.9.2
-Copyright © 2015 Basecamp, LLC
+Copyright © 2019 Basecamp, LLC
 http://trix-editor.org/
  */
 
@@ -1389,11 +1389,21 @@ http://trix-editor.org/
   Trix.config.textAttributes = {
     bold: {
       tagName: "b",
-      inheritable: true
+      inheritable: true,
+      parser: function(element) {
+        var style;
+        style = window.getComputedStyle(element);
+        return (style["fontWeight"] === "bold" || style["fontWeight"] >= 600) && style["fontSize"] === "12px";
+      }
     },
     italic: {
       tagName: "i",
-      inheritable: true
+      inheritable: true,
+      parser: function(element) {
+        var style;
+        style = window.getComputedStyle(element);
+        return style["fontStyle"] === "italic";
+      }
     },
     href: {
       groupTagName: "a",
@@ -1410,7 +1420,12 @@ http://trix-editor.org/
     },
     underline: {
       tagName: "u",
-      inheritable: true
+      inheritable: true,
+      parser: function(element) {
+        var style;
+        style = window.getComputedStyle(element);
+        return /underline/.test(style["textDecoration"]);
+      }
     },
     frozen: {
       style: {

--- a/dist/trix.css
+++ b/dist/trix.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
 Trix 0.9.2
-Copyright © 2015 Basecamp, LLC
+Copyright © 2019 Basecamp, LLC
 http://trix-editor.org/
 */
 trix-editor {

--- a/dist/trix.js
+++ b/dist/trix.js
@@ -1,7 +1,7 @@
 
 /*
 Trix 0.9.2
-Copyright © 2015 Basecamp, LLC
+Copyright © 2019 Basecamp, LLC
 http://trix-editor.org/
  */
 
@@ -2608,11 +2608,21 @@ window.CustomElements.addModule(function(scope) {
   Trix.config.textAttributes = {
     bold: {
       tagName: "b",
-      inheritable: true
+      inheritable: true,
+      parser: function(element) {
+        var style;
+        style = window.getComputedStyle(element);
+        return (style["fontWeight"] === "bold" || style["fontWeight"] >= 600) && style["fontSize"] === "12px";
+      }
     },
     italic: {
       tagName: "i",
-      inheritable: true
+      inheritable: true,
+      parser: function(element) {
+        var style;
+        style = window.getComputedStyle(element);
+        return style["fontStyle"] === "italic";
+      }
     },
     href: {
       groupTagName: "a",
@@ -2629,7 +2639,12 @@ window.CustomElements.addModule(function(scope) {
     },
     underline: {
       tagName: "u",
-      inheritable: true
+      inheritable: true,
+      parser: function(element) {
+        var style;
+        style = window.getComputedStyle(element);
+        return /underline/.test(style["textDecoration"]);
+      }
     },
     frozen: {
       style: {

--- a/src/trix/config/text_attributes.coffee
+++ b/src/trix/config/text_attributes.coffee
@@ -2,9 +2,15 @@ Trix.config.textAttributes =
   bold:
     tagName: "b"
     inheritable: true
+    parser: (element) ->
+      style = window.getComputedStyle(element)
+      (style["fontWeight"] is "bold" or style["fontWeight"] >= 600) and style["fontSize"] is "12px"
   italic:
     tagName: "i"
     inheritable: true
+    parser: (element) ->
+      style = window.getComputedStyle(element)
+      style["fontStyle"] is "italic"
   href:
     groupTagName: "a"
     parser: (element) ->
@@ -15,5 +21,8 @@ Trix.config.textAttributes =
   underline:
     tagName: "u"
     inheritable: true
+    parser: (element) ->
+      style = window.getComputedStyle(element)
+      /underline/.test(style["textDecoration"])
   frozen:
     style: { "backgroundColor": "highlight" }


### PR DESCRIPTION
fix: add a parser to `<b>`, `<i>` and `<u>` tags to correctly save formatting when multiple tags applied to a text